### PR TITLE
Fix TypeError

### DIFF
--- a/ipa_log_config.py
+++ b/ipa_log_config.py
@@ -406,7 +406,7 @@ def main():
             Auditd().log_to_syslog()
             Rsyslog().write_config(args.target, args.target_port)
             print 'Configuration completed successfully, IPA logs are ' \
-                'forwarded to ' + args.target + ':' + args.target_port
+                'forwarded to ' + args.target + ':' + str(args.target_port)
         elif args.revert:
             SSSD().enable_debug(1, False)
             Auditd().revert()


### PR DESCRIPTION
Fix TypeError:
<pre>
Traceback (most recent call last):
  File "./ipa_log_config.py", line 426, in <module>
    main()
  File "./ipa_log_config.py", line 409, in main
    'forwarded to ' + args.target + ':' + args.target_port
TypeError: cannot concatenate 'str' and 'int' objects
</pre>